### PR TITLE
Fix compilation warning for unused variable

### DIFF
--- a/lib/makeup/lexers/json_lexer.ex
+++ b/lib/makeup/lexers/json_lexer.ex
@@ -16,7 +16,7 @@ defmodule Makeup.Lexers.JsonLexer do
 
   whitespace = ascii_string(@known_whitespace_characters, min: 1) |> token(:whitespace)
 
-  newlines =
+  _newlines =
     choice([string("\r\n"), string("\n")])
     |> optional(ascii_string(@known_whitespace_characters, min: 1))
     |> token(:whitespace)


### PR DESCRIPTION
```
==> makeup_json
Compiling 3 files (.ex)
warning: variable "newlines" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/makeup/lexers/json_lexer.ex:17: Makeup.Lexers.JsonLexer
```